### PR TITLE
Allow use of custom paths

### DIFF
--- a/src/bash/bam-sort-cov.sh
+++ b/src/bash/bam-sort-cov.sh
@@ -56,7 +56,7 @@ if $parallel_mode; then
 				label=$(echo $(echo "$2" | sed 's/.*\///') | sed -e 's/.bam//g')						
 				# Sleep up to 10 seconds
 				echo "-- Running sort for $label ..." 2>&1 | tee -a $tmp_clog/bismark-sorting.log
-				ded=$(samtools sort -@ 4 -m 4G -o $tmp_covseq/sorted-$label.bam "$2")
+				ded=$($samtools_path sort -@ 4 -m 4G -o $tmp_covseq/sorted-$label.bam "$2")
 				: '
 				if [ -f $tmp_covseq/sorted-$label.bam ]
 				then
@@ -82,7 +82,7 @@ else
 				start=$(date +%s)
 				label=$(echo $(echo $bamfile | sed 's/.*\///') | sed -e 's/.bam//g')
 				echo "-- Running sort for $label ..." 
-				ded=$(samtools sort -@ 4 -m 4G -o $tmp_covseq/sorted-$label.bam $bamfile )
+				ded=$($samtools_path sort -@ 4 -m 4G -o $tmp_covseq/sorted-$label.bam $bamfile )
 				: '
 				if [ -f $tmp_covseq/sorted-$label.bam ]
 				then

--- a/src/bash/coverage-reports.sh
+++ b/src/bash/coverage-reports.sh
@@ -56,11 +56,11 @@ if $parallel_mode; then
 		. "$1"
 		label=$(echo $(echo $2 |sed 's/.*\///') | sed -e 's/.bam//g')
 		echo "-- Running genome coverage and sequencing depth for $label ..." 2>&1 | tee -a $tmp_clog/covseq.log
-		gen_size=$(samtools view -H $2  | grep -P '^@SQ' | cut -f 3 -d ':' | awk '{sum+=$1} END {print sum}')
-		cmd=$(samtools depth $2 | awk -v gen="$gen_size" '{sum+=$3} END {print "Average sequencing depth(X) = ",sum/gen}')
+		gen_size=$($samtools_path view -H $2  | grep -P '^@SQ' | cut -f 3 -d ':' | awk '{sum+=$1} END {print sum}')
+		cmd=$($samtools_path depth $2 | awk -v gen="$gen_size" '{sum+=$3} END {print "Average sequencing depth(X) = ",sum/gen}')
 		echo "# $cmd" 
 		#calculating genome coverage
-		gencov=$(bedtools genomecov -ibam $2 -bga -g $tmp_rdata/*_chr_all.txt | awk -v gen="$gen_size" '{if($4>0) total += ($3-$2)} END {print "Genome coverage (%) = ", total/gen * 100}')
+		gencov=$($bedtools_path genomecov -ibam $2 -bga -g $tmp_rdata/*_chr_all.txt | awk -v gen="$gen_size" '{if($4>0) total += ($3-$2)} END {print "Genome coverage (%) = ", total/gen * 100}')
 		echo "# ${gencov}" 
 
 		echo "file: " $label >> $tmp_covseq/$fileName-report.log
@@ -87,11 +87,11 @@ else
 			label=$(echo $(echo $file |sed 's/.*\///') | sed -e 's/.bam//g')
 			echo "-- Running genome coverage and sequencing depth $label ..." 2>&1 | tee -a $tmp_clog/covseq.log
 
-			gen_size=$(samtools view -H $file  | grep -P '^@SQ' | cut -f 3 -d ':' | awk '{sum+=$1} END {print sum}')
-			cmd=$(samtools depth $file | awk -v gen="$gen_size" '{sum+=$3} END {print "Average sequencing depth(X) = ",sum/gen}')
+			gen_size=$($samtools_path view -H $file  | grep -P '^@SQ' | cut -f 3 -d ':' | awk '{sum+=$1} END {print sum}')
+			cmd=$($samtools_path depth $file | awk -v gen="$gen_size" '{sum+=$3} END {print "Average sequencing depth(X) = ",sum/gen}')
 			echo "# $cmd" 
 			#calculating genome coverage
-			gencov=$(bedtools genomecov -ibam $file -bga -g $tmp_rdata/*_chr_all.txt | awk -v gen="$gen_size" '{if($4>0) total += ($3-$2)} END {print "Genome coverage (%) = ", total/gen * 100}')
+			gencov=$($bedtools_path genomecov -ibam $file -bga -g $tmp_rdata/*_chr_all.txt | awk -v gen="$gen_size" '{if($4>0) total += ($3-$2)} END {print "Genome coverage (%) = ", total/gen * 100}')
 			echo "# ${gencov}" 
 			echo "file: " $label >> $tmp_covseq/$fileName-report.log
 			echo "# $cmd" >> $tmp_covseq/$fileName-report.log

--- a/src/bash/gen-rdata.sh
+++ b/src/bash/gen-rdata.sh
@@ -14,7 +14,7 @@ if [ ! -f $tmp_rdata/Ref_Chr.RData ]
 		echo "Generating reference chromosome from Ref.genome  ..."
 		#copy genome_ref  to result directory because of reading/writing probabaly. 
 		pre_proc=$(cp $genome_ref/$genome_name $result_pipeline/rdata/)
-		a_proc= $(samtools faidx $tmp_rdata/$genome_name)
+		a_proc= $($samtools_path faidx $tmp_rdata/$genome_name)
 		tmp=$(echo $genome_name | sed 's/.*\///')
 		label=$(echo ${tmp%%.*})
 		b_proc= $(cut -f1,2 $tmp_rdata/*.fai > $tmp_rdata/$label.txt )


### PR DESCRIPTION
Although the user could provide alternative paths for samtools and bedtools during the configuration steps, these paths were not used when making the coverage reports, resulting in errors when these tools are not directly available in the PATH. Now the user specified paths are used when generating the coverage reports.